### PR TITLE
(SIMP-1595) Provide complete dependency boundaries

### DIFF
--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,3 +1,5 @@
-Requires: pupmod-simp-compliance_markup
-Requires: pupmod-simp-mozilla >= 2.0.0
 Obsoletes: pupmod-windowmanager-test
+Requires: pupmod-simp-compliance_markup < 2.0.0-0
+Requires: pupmod-simp-compliance_markup >= 1.0.1-0
+Requires: pupmod-simp-mozilla < 5.0.0-0
+Requires: pupmod-simp-mozilla >= 4.1.1-0

--- a/metadata.json
+++ b/metadata.json
@@ -1,21 +1,25 @@
 {
-  "name":    "simp-windowmanager",
-  "version": "4.1.2",
-  "author":  "simp",
+  "name": "simp-windowmanager",
+  "version": "4.1.3",
+  "author": "simp",
   "summary": "provides useful settings to set up various Window Managers.",
   "license": "Apache-2.0",
-  "source":  "https://github.com/simp/pupmod-simp-windowmanager",
+  "source": "https://github.com/simp/pupmod-simp-windowmanager",
   "project_page": "https://github.com/simp/pupmod-simp-windowmanager",
-  "issues_url":   "https://simp-project.atlassian.net",
-  "tags": [ "simp", "windowmanager", "gnome" ],
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "windowmanager",
+    "gnome"
+  ],
   "dependencies": [
     {
       "name": "simp/mozilla",
-      "version_requirement": ">= 2.0.0"
+      "version_requirement": ">= 4.1.1 < 5.0.0"
     },
     {
       "name": "simp/compliance_markup",
-      "version_requirement": ">= 1.0.0"
+      "version_requirement": ">= 1.0.1 < 2.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Before this patch, dependencies in `metadata.json` and
`build/rpm_metadata/requires` were missing upper boundaries and often
listed inaccurate lower boundaries.  This created an extremely fragile
5.2.X/4.3.X module ecosystem on the Forge, as a major release in any
dependency would be certain to break the module.

This commit resolves the issue by introducing upper and lower boundaries
for each dependency in `metadata.json` and propagates those dependencies
to the RPM dependencies listed in `build/rpm_metadata/requires`.

The minimum version boundaries were determined from the modules as they
were checked out in `simp-core` for the latest SIMP 5.2.X/4.3.X release
(with the addition recent z-version bumps from Forge-readiness patches).

SIMP-1595 #comment Fixed `pupmod-simp-windowmanager`
SIMP-1630 #close