### PR TITLE
(SIMP-1692) Point fixtures to `5.X` branches

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,14 +1,26 @@
 ---
 fixtures:
   repositories:
-    auditd:     "https://github.com/simp/pupmod-simp-auditd"
-    compliance_markup: "https://github.com/simp/pupmod-simp-compliance_markup"
-    iptables:   "https://github.com/simp/pupmod-simp-iptables"
-    mozilla:    "https://github.com/simp/pupmod-simp-mozilla"
-    simplib:    "https://github.com/simp/pupmod-simp-simplib"
+    auditd:
+      repo: https://github.com/simp/pupmod-simp-auditd
+      branch: 5.X
+    compliance_markup:
+      repo: https://github.com/simp/pupmod-simp-compliance_markup
+      branch: 5.X
+    iptables:
+      repo: https://github.com/simp/pupmod-simp-iptables
+      branch: 5.X
+    mozilla:
+      repo: https://github.com/simp/pupmod-simp-mozilla
+      branch: 5.X
+    simplib:
+      repo: https://github.com/simp/pupmod-simp-simplib
+      branch: 5.X
     stdlib:
-      repo: "https://github.com/simp/puppetlabs-stdlib"
-      branch: "simp-master"
-    xwindows:   "https://github.com/simp/pupmod-simp-xwindows"
+      branch: 5.X
+      repo: https://github.com/simp/puppetlabs-stdlib
+    xwindows:
+      repo: https://github.com/simp/pupmod-simp-xwindows
+      branch: 5.X
   symlinks:
     windowmanager: "#{source_dir}"


### PR DESCRIPTION
This commit marks the transition of mainline SIMP development away from
4.x/5.x.  From this point on, the `master` branch will be used to target SIMP
6.x.

This commit updates `fixtures.yml` to reference the newly-created `5.X` branch
in each `simp/` repository.

SIMP-1692 #comment updated `.fixtures.yml` in windowmanager